### PR TITLE
skip creating current dir

### DIFF
--- a/revolver/project.py
+++ b/revolver/project.py
@@ -68,9 +68,10 @@ class Deployinator(object):
     def _layout(self):
         current_user = core.run("echo $USER").stdout
 
-        for path in self.folders.itervalues():
+        for type, path in self.folders.iteritems():
             if not dir.exists(path):
-                dir.create(path, recursive=True)
+                if type != "current":
+                    dir.create(path, recursive=True)
             else:
                 dir.attributes(path, owner=current_user, recursive=True)
 


### PR DESCRIPTION
We must not create the "current" directory. It will be linked during deployment.

```
[jan@gullinborsti] run: rm -f -r /home/jan/LitGreip/releases/20120407T104534Z
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/fabric/main.py", line 712, in main
    *args, **kwargs
  File "/usr/local/lib/python2.7/dist-packages/fabric/tasks.py", line 298, in execute
    multiprocessing
  File "/usr/local/lib/python2.7/dist-packages/fabric/tasks.py", line 197, in _execute
    return task.run(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/fabric/tasks.py", line 112, in run
    return self.wrapped(*args, **kwargs)
  File "/home/jan/Workspace/Private/LitGreip/fabfile.py", line 17, in deploy
    dp.run()
  File "/usr/local/lib/python2.7/dist-packages/revolver/project.py", line 46, in run
    self._activate()
  File "/usr/local/lib/python2.7/dist-packages/revolver/project.py", line 97, in _activate
    file.link(self.folders["releases.current"], self.folders["current"])
  File "/usr/local/lib/python2.7/dist-packages/cuisine.py", line 457, in file_link
    raise Exception("Destination already exists and is not a link: %s" % (destination))
Exception: Destination already exists and is not a link: /home/jan/LitGreip/current
Disconnecting from gullinborsti... done.
```
